### PR TITLE
Trigger popup on auto-focused password fields

### DIFF
--- a/src/page/bootstrap.js
+++ b/src/page/bootstrap.js
@@ -6,3 +6,10 @@ var boot = function(event){
 	}
 };
 document.addEventListener('focusin', boot);
+
+/* explicitly fire a focus event for autofocused password fields */
+if (document.activeElement && document.activeElement.tagName == 'INPUT' && document.activeElement.type == 'password') {
+    var event =  document.createEvent("HTMLEvents");
+    event.initEvent("focusin", true, true);
+    document.activeElement.dispatchEvent(event);
+}


### PR DESCRIPTION
Recently ChromeGenPass has stopped triggering the popup window on auto-focused password fields. The user has to click outside the password field, then re-click inside the password to trigger the popup.

Example: http://jsfiddle.net/HCFQP/

Was this done on purpose or is this a bug?

Anyway, this change explicitly fires a focus event on the focused password field on pageload, triggering the popup window.
